### PR TITLE
Fix release detection: move detect-release after JDK setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: '25'
+          server-id: github
+
       - name: Detect release request
         id: detect-release
         if: github.ref == 'refs/heads/master' && !contains(github.event.head_commit.message, '[skip ci]')
@@ -38,13 +45,6 @@ jobs:
             CURRENT=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
             echo "release_version=${CURRENT%-SNAPSHOT}" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Set up JDK 25
-        uses: actions/setup-java@v5
-        with:
-          distribution: zulu
-          java-version: '25'
-          server-id: github
 
       - name: Cache Maven repository
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary

Move the detect-release step after JDK setup. When the commit message is `[release]` (without explicit version), the step falls back to `mvn help:evaluate` which requires JDK on PATH.

The `[release] 1.0.0` PR was squash-merged as `[release] 1.0.0 (#4)` — the version is outside the brackets, so the explicit-version regex doesn't match and it falls through to the mvn fallback, which fails without JDK.