### PR TITLE
Add git identity for release commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,8 @@ jobs:
         env:
           RELEASE_VERSION: ${{ needs.build.outputs.release_version }}
         run: |
+          git config --global user.email "supervisor@karellen.co"
+          git config --global user.name "Karellen Supervisor"
           # Compute next development version (increment patch)
           IFS='.' read -r MAJOR MINOR PATCH <<< "$RELEASE_VERSION"
           NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-SNAPSHOT"


### PR DESCRIPTION
Fix: release job fails with 'empty ident name not allowed' because git user.name/email not configured.