### PR TITLE
Use PAT_TOKEN for release pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5


### PR DESCRIPTION
GITHUB_TOKEN cannot push to protected branches. Use PAT_TOKEN for the release checkout so git push succeeds.