### PR TITLE
Add GitHub Release creation to release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,12 @@ jobs:
           # Atomic push: both master and tag in one transaction
           git push --atomic origin master "v${RELEASE_VERSION}"
 
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.build.outputs.release_version }}
+          generate_release_notes: true
+
   publish:
     needs: build
     if: >-


### PR DESCRIPTION
Create a GitHub Release with auto-generated release notes when a version is tagged.