### PR TITLE
Fix call hierarchy and bidirectional Java↔Kotlin property/getter interop (#12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,8 @@ ANTLR4-based Kotlin parser with 7-phase pipeline: declaration extraction, symbol
 table, scope-based type resolution, overload resolution, lambda type propagation,
 smart cast narrowing, index emission, and IJavaElement resolution. All cross-language
 LSP features working: find references, go-to-definition, hover, call hierarchy, type
-hierarchy, document symbols, and code lens. 231 integration tests, 85% instruction /
-65% branch coverage. Product module produces a self-contained distribution (~48MB
-tar.gz) with native Eclipse launcher (`jdtls`), all jdtls bundles, and the Kotlin
-plugin.
+hierarchy, document symbols, and code lens. Bidirectional Java↔Kotlin property/getter
+interop: searching for Java `getName()` finds Kotlin `obj.name` access and vice
+versa. 275 integration tests, 87% instruction / 68% branch coverage. Product module
+produces a self-contained distribution (~48MB tar.gz) with native Eclipse launcher
+(`jdtls`), all jdtls bundles, and the Kotlin plugin.

--- a/co.karellen.jdtls.kotlin.tests/src/co/karellen/jdtls/kotlin/tests/CrossLanguageCallHierarchyTest.java
+++ b/co.karellen.jdtls.kotlin.tests/src/co/karellen/jdtls/kotlin/tests/CrossLanguageCallHierarchyTest.java
@@ -956,4 +956,1206 @@ public class CrossLanguageCallHierarchyTest {
 				"Should find anotherJavaMethod as outgoing callee. Found: "
 						+ calleeNames);
 	}
+
+	// ---- Bug #12: top-level declarations need non-null declaring type ----
+	//
+	// JDT infrastructure assumes every IMember has a non-null declaring
+	// type. Kotlin top-level functions/properties compile to static
+	// members of a synthetic FileNameKt class. All code paths that
+	// create KotlinMethodElement or KotlinFieldElement for top-level
+	// declarations must set a file-facade declaring type.
+	//
+	// Code paths tested:
+	// 1. reportMethodMatch — declaration search (MethodPattern+DECL)
+	// 2. reportFieldMatch — declaration search (FieldPattern+DECL)
+	// 3. createElementForDeclaration — reference match enclosing element
+	// 4. KotlinModelManager.populateCompilationUnit — CU model/codeSelect
+	// 5. CalleeMethodWrapper E2E — outgoing calls with top-level callee
+	// 6. CallerMethodWrapper E2E — incoming calls from top-level caller
+
+	// ---- Path 1: reportMethodMatch (declaration search) ----
+
+	@Test
+	public void testTopLevelFunctionDeclaringTypeViaDeclarationSearch()
+			throws Exception {
+		// MethodPattern with DECLARATIONS → locateMatchesInDeclaration
+		// → reportMethodMatch creates KotlinMethodElement
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/p1");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/p1/MyUtils.kt",
+				"package p1\n"
+				+ "\n"
+				+ "fun topLevelFun(): String = \"hello\"\n"
+				+ "\n"
+				+ "fun anotherTopLevel(x: Int): Boolean = x > 0\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		for (String name : new String[] { "topLevelFun",
+				"anotherTopLevel" }) {
+			List<SearchMatch> matches = TestHelpers
+					.searchMethodDeclarations(name, project);
+			List<SearchMatch> ktMatches = TestHelpers
+					.filterKotlinMatches(matches);
+			assertTrue(ktMatches.size() >= 1,
+					"Should find " + name + " declaration");
+
+			IMember method = (IMember) ktMatches.get(0).getElement();
+			assertNotNull(method.getDeclaringType(),
+					"Top-level function " + name
+							+ " should have non-null declaring type");
+			assertNotNull(method.getDeclaringType()
+							.getFullyQualifiedName(),
+					"Declaring type of " + name
+							+ " should have FQN");
+			assertTrue(method.getDeclaringType()
+							.getFullyQualifiedName()
+							.contains("MyUtils"),
+					"File-facade type should contain file name. Got: "
+							+ method.getDeclaringType()
+									.getFullyQualifiedName());
+		}
+	}
+
+	// ---- Path 2: reportFieldMatch (declaration search) ----
+
+	@Test
+	public void testTopLevelPropertyDeclaringTypeViaDeclarationSearch()
+			throws Exception {
+		// FieldPattern with DECLARATIONS → locateMatchesInDeclaration
+		// → reportFieldMatch creates KotlinFieldElement
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/p2");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/p2/Constants.kt",
+				"package p2\n"
+				+ "\n"
+				+ "val TIMEOUT: Long = 30000L\n"
+				+ "\n"
+				+ "val MAX_RETRIES: Int = 3\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		for (String name : new String[] { "TIMEOUT", "MAX_RETRIES" }) {
+			List<SearchMatch> matches = TestHelpers
+					.searchFieldDeclarations(name, project);
+			List<SearchMatch> ktMatches = TestHelpers
+					.filterKotlinMatches(matches);
+			assertTrue(ktMatches.size() >= 1,
+					"Should find " + name + " declaration");
+
+			IMember field = (IMember) ktMatches.get(0).getElement();
+			assertNotNull(field.getDeclaringType(),
+					"Top-level property " + name
+							+ " should have non-null declaring type");
+			assertNotNull(field.getDeclaringType()
+							.getFullyQualifiedName(),
+					"Declaring type of " + name
+							+ " should have FQN");
+			assertTrue(field.getDeclaringType()
+							.getFullyQualifiedName()
+							.contains("Constants"),
+					"File-facade type should contain file name. Got: "
+							+ field.getDeclaringType()
+									.getFullyQualifiedName());
+		}
+	}
+
+	// ---- Path 3: createElementForDeclaration (reference matches) ----
+
+	@Test
+	public void testTopLevelFunctionAsEnclosingElementInReferenceSearch()
+			throws Exception {
+		// When a reference to a Java method is found inside a top-level
+		// Kotlin function, the match element is the enclosing function.
+		// createElementForDeclaration must set a declaring type on it.
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/p3");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/p3/Target.java",
+				"package p3;\n"
+				+ "public class Target {\n"
+				+ "    public static void doSomething() {}\n"
+				+ "}\n");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/p3/TopCaller.kt",
+				"package p3\n"
+				+ "\n"
+				+ "fun topLevelCaller() {\n"
+				+ "    Target.doSomething()\n"
+				+ "}\n"
+				+ "\n"
+				+ "fun anotherTopCaller() {\n"
+				+ "    Target.doSomething()\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		List<SearchMatch> refs = TestHelpers
+				.searchMethodReferences("doSomething", project);
+		List<SearchMatch> ktRefs = TestHelpers
+				.filterKotlinMatches(refs);
+		assertTrue(ktRefs.size() >= 2,
+				"Should find at least 2 Kotlin references to "
+						+ "doSomething. Found: " + ktRefs.size());
+
+		for (SearchMatch match : ktRefs) {
+			IMember enclosing = (IMember) match.getElement();
+			assertNotNull(enclosing.getDeclaringType(),
+					"Enclosing top-level function '"
+							+ enclosing.getElementName()
+							+ "' should have non-null declaring type");
+			assertNotNull(enclosing.getDeclaringType()
+							.getFullyQualifiedName(),
+					"Declaring type of enclosing '"
+							+ enclosing.getElementName()
+							+ "' should have FQN");
+		}
+	}
+
+	// ---- Path 4: KotlinModelManager.populateCompilationUnit ----
+
+	@Test
+	public void testTopLevelFunctionDeclaringTypeViaCUModel()
+			throws Exception {
+		// KotlinModelManager.populateCompilationUnit builds top-level
+		// functions as children of the CU. These are used by
+		// codeSelect() which is called by CallHierarchyHandler.
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/p4");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/p4/Helpers.kt",
+				"package p4\n"
+				+ "\n"
+				+ "fun helperOne(): String = \"one\"\n"
+				+ "\n"
+				+ "val helperProp: Int = 99\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		IFile ktFile = TestHelpers.getFile(
+				"/" + PROJECT_NAME + "/src/p4/Helpers.kt");
+		KotlinCompilationUnit cu = KotlinModelManager.getInstance()
+				.getCompilationUnit(ktFile);
+		assertNotNull(cu, "CU should not be null");
+
+		IJavaElement[] children = cu.getChildren();
+		boolean foundMethod = false;
+		boolean foundField = false;
+		for (IJavaElement child : children) {
+			if (child instanceof IMethod m
+					&& "helperOne".equals(m.getElementName())) {
+				foundMethod = true;
+				assertNotNull(((IMember) m).getDeclaringType(),
+						"Top-level function helperOne from CU model "
+								+ "should have non-null declaring type");
+			}
+			if (child instanceof KotlinElement.KotlinFieldElement f
+					&& "helperProp".equals(f.getElementName())) {
+				foundField = true;
+				assertNotNull(f.getDeclaringType(),
+						"Top-level property helperProp from CU model "
+								+ "should have non-null declaring type");
+			}
+		}
+		assertTrue(foundMethod,
+				"Should find helperOne in CU children");
+		assertTrue(foundField,
+				"Should find helperProp in CU children");
+	}
+
+	// ---- Path 5: E2E outgoing calls with top-level callee ----
+
+	@Test
+	public void testOutgoingCallsWithTopLevelFunctionCallee()
+			throws Exception {
+		// CalleeMethodWrapper.findCalleesFromParticipants → resolveCallee
+		// finds a KotlinMethodElement → CallSearchResultCollector.addMember
+		// → isIgnored → getTypeOfElement(callee).getFullyQualifiedName()
+		// NPE when declaring type is null.
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/p5");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/p5/Utils.kt",
+				"package p5\n"
+				+ "\n"
+				+ "fun <T> dslFor(block: () -> T): T = block()\n"
+				+ "\n"
+				+ "fun helperFunction(s: String): Int = s.length\n");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/p5/Service.kt",
+				"package p5\n"
+				+ "\n"
+				+ "class Service {\n"
+				+ "    fun doWork(): Int {\n"
+				+ "        val result = dslFor {"
+				+ " helperFunction(\"test\") }\n"
+				+ "        return result\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		List<SearchMatch> matches = TestHelpers
+				.searchMethodDeclarations("doWork", project);
+		List<SearchMatch> ktMatches = TestHelpers
+				.filterKotlinMatches(matches);
+		assertTrue(ktMatches.size() >= 1,
+				"Should find doWork declaration");
+
+		IMember kotlinMethod = (IMember) ktMatches.get(0).getElement();
+
+		MethodWrapper[] roots = CallHierarchyCore.getDefault()
+				.getCalleeRoots(new IMember[] { kotlinMethod });
+		assertEquals(1, roots.length, "Should have one root");
+
+		// This call throws NPE without the fix
+		MethodWrapper[] callees = roots[0].getCalls(
+				new NullProgressMonitor());
+
+		Set<String> calleeNames = new HashSet<>();
+		for (MethodWrapper callee : callees) {
+			calleeNames.add(callee.getMember().getElementName());
+		}
+		assertTrue(calleeNames.contains("dslFor"),
+				"Should find top-level dslFor. Found: " + calleeNames);
+		assertTrue(calleeNames.contains("helperFunction"),
+				"Should find top-level helperFunction. Found: "
+						+ calleeNames);
+	}
+
+	// ---- Path 6: E2E incoming calls from top-level caller ----
+
+	@Test
+	public void testIncomingCallsFromTopLevelFunction()
+			throws Exception {
+		// CallerMethodWrapper uses SearchEngine to find callers.
+		// When the caller is a top-level Kotlin function, the match
+		// element must have a non-null declaring type for
+		// CallSearchResultCollector.isIgnored and for
+		// toCallHierarchyItem in jdtls.
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/p6");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/p6/Api.java",
+				"package p6;\n"
+				+ "public class Api {\n"
+				+ "    public static String fetchData() {"
+				+ " return \"data\"; }\n"
+				+ "}\n");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/p6/TopConsumer.kt",
+				"package p6\n"
+				+ "\n"
+				+ "fun consumeFromTop(): String {\n"
+				+ "    return Api.fetchData()\n"
+				+ "}\n"
+				+ "\n"
+				+ "fun anotherConsumer(): String {\n"
+				+ "    return Api.fetchData()\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		// Find the Java method
+		ICompilationUnit javaCu = TestHelpers.getJavaCompilationUnit(
+				project, "p6", "Api.java");
+		assertNotNull(javaCu, "Java CU should exist");
+		IType apiType = javaCu.getType("Api");
+		IMethod fetchData = apiType.getMethod("fetchData",
+				new String[0]);
+		assertTrue(fetchData.exists(),
+				"Api.fetchData() should exist");
+
+		// Incoming calls via CallHierarchyCore
+		MethodWrapper[] roots = CallHierarchyCore.getDefault()
+				.getCallerRoots(new IMember[] { fetchData });
+		assertEquals(1, roots.length, "Should have one root");
+
+		MethodWrapper[] callers = roots[0].getCalls(
+				new NullProgressMonitor());
+
+		Set<String> callerNames = new HashSet<>();
+		for (MethodWrapper caller : callers) {
+			IMember member = caller.getMember();
+			callerNames.add(member.getElementName());
+			// The declaring type must be non-null for
+			// CallHierarchyHandler.toCallHierarchyItem to work
+			assertNotNull(member.getDeclaringType(),
+					"Top-level caller '" + member.getElementName()
+							+ "' should have non-null declaring type");
+		}
+		assertTrue(callerNames.contains("consumeFromTop"),
+				"Should find consumeFromTop as caller. Found: "
+						+ callerNames);
+		assertTrue(callerNames.contains("anotherConsumer"),
+				"Should find anotherConsumer as caller. Found: "
+						+ callerNames);
+	}
+
+	// ---- Top-level extension functions (variant of path 1) ----
+
+	@Test
+	public void testTopLevelExtensionFunctionDeclaringType()
+			throws Exception {
+		// Extension functions are also top-level — they must also have
+		// a file-facade declaring type.
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/p7");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/p7/Extensions.kt",
+				"package p7\n"
+				+ "\n"
+				+ "fun String.greet(): String = \"Hello, $this!\"\n"
+				+ "\n"
+				+ "fun Int.isEven(): Boolean = this % 2 == 0\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		for (String name : new String[] { "greet", "isEven" }) {
+			List<SearchMatch> matches = TestHelpers
+					.searchMethodDeclarations(name, project);
+			List<SearchMatch> ktMatches = TestHelpers
+					.filterKotlinMatches(matches);
+			assertTrue(ktMatches.size() >= 1,
+					"Should find " + name + " declaration");
+
+			IMember method = (IMember) ktMatches.get(0).getElement();
+			assertNotNull(method.getDeclaringType(),
+					"Top-level extension " + name
+							+ " should have non-null declaring type");
+			assertTrue(method.getDeclaringType()
+							.getFullyQualifiedName()
+							.contains("Extensions"),
+					"File-facade type should contain 'Extensions'. "
+							+ "Got: " + method.getDeclaringType()
+									.getFullyQualifiedName());
+		}
+	}
+
+	// ---- Nested type declaring type ----
+
+	@Test
+	public void testNestedTypeDeclaringTypeNotNull() throws Exception {
+		// KotlinTypeElement inherits base getDeclaringType() which
+		// returns null. For nested types (Inner inside Outer),
+		// getDeclaringType() should return the enclosing type.
+		// JDT uses this for parent navigation, breadcrumbs, and
+		// call hierarchy type resolution.
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/nested");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/nested/Outer.kt",
+				"package nested\n"
+				+ "\n"
+				+ "class Outer {\n"
+				+ "    class Inner {\n"
+				+ "        fun innerMethod(): String = \"inner\"\n"
+				+ "    }\n"
+				+ "    class AnotherInner {\n"
+				+ "        fun anotherMethod(): Int = 42\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		// Find Inner class via type declaration search
+		SearchPattern pattern = SearchPattern.createPattern(
+				"Inner", IJavaSearchConstants.TYPE,
+				IJavaSearchConstants.DECLARATIONS,
+				SearchPattern.R_EXACT_MATCH);
+		List<SearchMatch> matches = new ArrayList<>();
+		new SearchEngine().search(pattern,
+				SearchEngine.getSearchParticipants(),
+				SearchEngine.createJavaSearchScope(
+						new IJavaProject[] { project }),
+				new SearchRequestor() {
+					@Override
+					public void acceptSearchMatch(SearchMatch match) {
+						matches.add(match);
+					}
+				}, new NullProgressMonitor());
+
+		List<SearchMatch> ktMatches = TestHelpers
+				.filterKotlinMatches(matches);
+		assertTrue(ktMatches.size() >= 1,
+				"Should find Inner type declaration");
+
+		IType innerType = (IType) ktMatches.get(0).getElement();
+		assertNotNull(innerType.getDeclaringType(),
+				"Nested type Inner should have non-null "
+						+ "declaring type (Outer)");
+		assertEquals("Outer",
+				innerType.getDeclaringType().getElementName(),
+				"Inner's declaring type should be Outer");
+	}
+
+	@Test
+	public void testNestedTypeMethodDeclaringTypeChain()
+			throws Exception {
+		// Method inside nested type: method.getDeclaringType() should
+		// return the nested type, which in turn should have
+		// getDeclaringType() returning the outer type.
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/chain");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/chain/Container.kt",
+				"package chain\n"
+				+ "\n"
+				+ "class Container {\n"
+				+ "    class Nested {\n"
+				+ "        fun nestedWork(): Boolean = true\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		List<SearchMatch> matches = TestHelpers
+				.searchMethodDeclarations("nestedWork", project);
+		List<SearchMatch> ktMatches = TestHelpers
+				.filterKotlinMatches(matches);
+		assertTrue(ktMatches.size() >= 1,
+				"Should find nestedWork declaration");
+
+		IMember method = (IMember) ktMatches.get(0).getElement();
+		IType declaringType = method.getDeclaringType();
+		assertNotNull(declaringType,
+				"nestedWork should have declaring type");
+		assertEquals("Nested", declaringType.getElementName(),
+				"nestedWork's declaring type should be Nested");
+
+		// Nested's declaring type should be Container
+		assertNotNull(declaringType.getDeclaringType(),
+				"Nested should have declaring type Container");
+		assertEquals("Container",
+				declaringType.getDeclaringType().getElementName(),
+				"Nested's declaring type should be Container");
+	}
+
+	// ---- Outgoing calls from nested type method ----
+
+	@Test
+	public void testOutgoingCallsFromNestedTypeMethod()
+			throws Exception {
+		// Outgoing call hierarchy from a method inside a nested type.
+		// The caller member's declaring type chain must be intact for
+		// CallSearchResultCollector.isIgnored() to work.
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/nestcall");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/nestcall/Api.java",
+				"package nestcall;\n"
+				+ "public class Api {\n"
+				+ "    public static void apiCall() {}\n"
+				+ "}\n");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/nestcall/Wrapper.kt",
+				"package nestcall\n"
+				+ "\n"
+				+ "class Wrapper {\n"
+				+ "    class Handler {\n"
+				+ "        fun handle() {\n"
+				+ "            Api.apiCall()\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		List<SearchMatch> matches = TestHelpers
+				.searchMethodDeclarations("handle", project);
+		List<SearchMatch> ktMatches = TestHelpers
+				.filterKotlinMatches(matches);
+		assertTrue(ktMatches.size() >= 1,
+				"Should find handle declaration");
+
+		IMember kotlinMethod = (IMember) ktMatches.get(0).getElement();
+		MethodWrapper[] roots = CallHierarchyCore.getDefault()
+				.getCalleeRoots(new IMember[] { kotlinMethod });
+		assertEquals(1, roots.length, "Should have one root");
+
+		MethodWrapper[] callees = roots[0].getCalls(
+				new NullProgressMonitor());
+		Set<String> calleeNames = new HashSet<>();
+		for (MethodWrapper callee : callees) {
+			calleeNames.add(callee.getMember().getElementName());
+		}
+		assertTrue(calleeNames.contains("apiCall"),
+				"Should find apiCall as outgoing callee from nested "
+						+ "type method. Found: " + calleeNames);
+	}
+
+	// ---- Incoming calls to nested type method ----
+
+	@Test
+	public void testIncomingCallsToNestedTypeMethod()
+			throws Exception {
+		// Incoming call hierarchy where the caller is inside a nested
+		// Kotlin type. The match element's declaring type chain must
+		// be non-null for CallSearchResultCollector.
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/nestin");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/nestin/Target.java",
+				"package nestin;\n"
+				+ "public class Target {\n"
+				+ "    public static int compute() { return 1; }\n"
+				+ "}\n");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/nestin/Caller.kt",
+				"package nestin\n"
+				+ "\n"
+				+ "class Caller {\n"
+				+ "    class Inner {\n"
+				+ "        fun callFromInner(): Int {\n"
+				+ "            return Target.compute()\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		ICompilationUnit javaCu = TestHelpers.getJavaCompilationUnit(
+				project, "nestin", "Target.java");
+		IType targetType = javaCu.getType("Target");
+		IMethod compute = targetType.getMethod("compute",
+				new String[0]);
+		assertTrue(compute.exists(), "Target.compute() should exist");
+
+		MethodWrapper[] roots = CallHierarchyCore.getDefault()
+				.getCallerRoots(new IMember[] { compute });
+		assertEquals(1, roots.length, "Should have one root");
+
+		MethodWrapper[] callers = roots[0].getCalls(
+				new NullProgressMonitor());
+		boolean found = false;
+		for (MethodWrapper caller : callers) {
+			IMember member = caller.getMember();
+			if ("callFromInner".equals(member.getElementName())) {
+				found = true;
+				assertNotNull(member.getDeclaringType(),
+						"callFromInner should have declaring type");
+				assertEquals("Inner",
+						member.getDeclaringType().getElementName(),
+						"callFromInner's declaring type should be "
+								+ "Inner");
+			}
+		}
+		assertTrue(found,
+				"Should find callFromInner as caller. Found: "
+						+ Arrays.stream(callers)
+								.map(c -> c.getMember()
+										.getElementName())
+								.collect(Collectors.joining(", ")));
+	}
+
+	// ---- CU model for nested types ----
+
+	@Test
+	public void testNestedTypeDeclaringTypeViaCUModel()
+			throws Exception {
+		// KotlinModelManager.populateCompilationUnit builds type
+		// elements. Nested types via CU model (used by codeSelect)
+		// should have declaring type set.
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/cumodel");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/cumodel/Parent.kt",
+				"package cumodel\n"
+				+ "\n"
+				+ "class Parent {\n"
+				+ "    class Child {\n"
+				+ "        fun childMethod() {}\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		IFile ktFile = TestHelpers.getFile(
+				"/" + PROJECT_NAME + "/src/cumodel/Parent.kt");
+		KotlinCompilationUnit cu = KotlinModelManager.getInstance()
+				.getCompilationUnit(ktFile);
+		assertNotNull(cu, "CU should not be null");
+
+		// Find the Parent type in CU model
+		IType[] types = cu.getTypes();
+		assertTrue(types.length >= 1, "Should have at least one type");
+		IType parentType = null;
+		for (IType t : types) {
+			if ("Parent".equals(t.getElementName())) {
+				parentType = t;
+			}
+		}
+		assertNotNull(parentType, "Should find Parent type");
+
+		// Parent's declaring type should be null (top-level type)
+		// — this is correct; top-level types don't have a declaring type
+
+		// Find Child as a nested type within Parent's children
+		IJavaElement[] children = parentType.getChildren();
+		IType childType = null;
+		for (IJavaElement child : children) {
+			if (child instanceof IType t
+					&& "Child".equals(t.getElementName())) {
+				childType = t;
+			}
+		}
+		assertNotNull(childType, "Should find Child in Parent's "
+				+ "children");
+		assertNotNull(childType.getDeclaringType(),
+				"Nested type Child should have non-null declaring "
+						+ "type via CU model");
+		assertEquals("Parent",
+				childType.getDeclaringType().getElementName(),
+				"Child's declaring type should be Parent");
+	}
+
+	// ---- Deep nesting (3+ levels) ----
+	//
+	// Parser stores enclosingTypeName as peek() from a stack, which
+	// only gives the immediate parent name. For Outer.Middle.Inner,
+	// Inner gets enclosingTypeName="Middle" instead of "Outer.Middle".
+	// This breaks FQN construction, declaring type chains, and search.
+
+	@Test
+	public void testDeeplyNestedTypeFQN() throws Exception {
+		// 3-level nesting: Outer > Middle > Inner
+		// Inner.getFullyQualifiedName() must be "deep.Outer.Middle.Inner"
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/deep");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/deep/Outer.kt",
+				"package deep\n"
+				+ "\n"
+				+ "class Outer {\n"
+				+ "    class Middle {\n"
+				+ "        class Inner {\n"
+				+ "            fun innerMethod(): String = \"deep\"\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		// Search for Inner type
+		SearchPattern pattern = SearchPattern.createPattern(
+				"Inner", IJavaSearchConstants.TYPE,
+				IJavaSearchConstants.DECLARATIONS,
+				SearchPattern.R_EXACT_MATCH);
+		List<SearchMatch> matches = new ArrayList<>();
+		new SearchEngine().search(pattern,
+				SearchEngine.getSearchParticipants(),
+				SearchEngine.createJavaSearchScope(
+						new IJavaProject[] { project }),
+				new SearchRequestor() {
+					@Override
+					public void acceptSearchMatch(SearchMatch match) {
+						matches.add(match);
+					}
+				}, new NullProgressMonitor());
+
+		List<SearchMatch> ktMatches = TestHelpers
+				.filterKotlinMatches(matches);
+		assertTrue(ktMatches.size() >= 1,
+				"Should find Inner type declaration");
+
+		IType innerType = (IType) ktMatches.get(0).getElement();
+		assertEquals("deep.Outer.Middle.Inner",
+				innerType.getFullyQualifiedName(),
+				"3-level nested type FQN should include full chain");
+	}
+
+	@Test
+	public void testDeeplyNestedDeclaringTypeChain() throws Exception {
+		// Full declaring type chain: Inner → Middle → Outer
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/chain3");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/chain3/A.kt",
+				"package chain3\n"
+				+ "\n"
+				+ "class A {\n"
+				+ "    class B {\n"
+				+ "        class C {\n"
+				+ "            fun cMethod(): Int = 1\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		List<SearchMatch> matches = TestHelpers
+				.searchMethodDeclarations("cMethod", project);
+		List<SearchMatch> ktMatches = TestHelpers
+				.filterKotlinMatches(matches);
+		assertTrue(ktMatches.size() >= 1,
+				"Should find cMethod declaration");
+
+		IMember method = (IMember) ktMatches.get(0).getElement();
+		IType c = method.getDeclaringType();
+		assertNotNull(c, "cMethod declaring type should be C");
+		assertEquals("C", c.getElementName());
+
+		IType b = c.getDeclaringType();
+		assertNotNull(b, "C's declaring type should be B");
+		assertEquals("B", b.getElementName());
+
+		IType a = b.getDeclaringType();
+		assertNotNull(a, "B's declaring type should be A");
+		assertEquals("A", a.getElementName());
+	}
+
+	@Test
+	public void testDeeplyNestedOutgoingCallHierarchy() throws Exception {
+		// Outgoing calls from a method 3 levels deep should not throw
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/deepcall");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/deepcall/Api.java",
+				"package deepcall;\n"
+				+ "public class Api {\n"
+				+ "    public static void deepTarget() {}\n"
+				+ "}\n");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/deepcall/Levels.kt",
+				"package deepcall\n"
+				+ "\n"
+				+ "class Level1 {\n"
+				+ "    class Level2 {\n"
+				+ "        class Level3 {\n"
+				+ "            fun callFromDeep() {\n"
+				+ "                Api.deepTarget()\n"
+				+ "            }\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		List<SearchMatch> matches = TestHelpers
+				.searchMethodDeclarations("callFromDeep", project);
+		List<SearchMatch> ktMatches = TestHelpers
+				.filterKotlinMatches(matches);
+		assertTrue(ktMatches.size() >= 1,
+				"Should find callFromDeep declaration");
+
+		IMember kotlinMethod = (IMember) ktMatches.get(0).getElement();
+		MethodWrapper[] roots = CallHierarchyCore.getDefault()
+				.getCalleeRoots(new IMember[] { kotlinMethod });
+		assertEquals(1, roots.length, "Should have one root");
+
+		MethodWrapper[] callees = roots[0].getCalls(
+				new NullProgressMonitor());
+		Set<String> calleeNames = new HashSet<>();
+		for (MethodWrapper callee : callees) {
+			calleeNames.add(callee.getMember().getElementName());
+		}
+		assertTrue(calleeNames.contains("deepTarget"),
+				"Should find deepTarget from 3-level nested caller. "
+						+ "Found: " + calleeNames);
+	}
+
+	@Test
+	public void testDeeplyNestedIncomingCallHierarchy() throws Exception {
+		// Incoming calls where the Kotlin caller is 3 levels deep
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/deepin");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/deepin/Target.java",
+				"package deepin;\n"
+				+ "public class Target {\n"
+				+ "    public static int getValue() { return 42; }\n"
+				+ "}\n");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/deepin/Deep.kt",
+				"package deepin\n"
+				+ "\n"
+				+ "class Outer {\n"
+				+ "    class Middle {\n"
+				+ "        class Inner {\n"
+				+ "            fun useTarget(): Int {\n"
+				+ "                return Target.getValue()\n"
+				+ "            }\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		ICompilationUnit javaCu = TestHelpers.getJavaCompilationUnit(
+				project, "deepin", "Target.java");
+		IType targetType = javaCu.getType("Target");
+		IMethod getValue = targetType.getMethod("getValue",
+				new String[0]);
+		assertTrue(getValue.exists(), "Target.getValue() should exist");
+
+		MethodWrapper[] roots = CallHierarchyCore.getDefault()
+				.getCallerRoots(new IMember[] { getValue });
+		assertEquals(1, roots.length, "Should have one root");
+
+		MethodWrapper[] callers = roots[0].getCalls(
+				new NullProgressMonitor());
+		boolean found = false;
+		for (MethodWrapper caller : callers) {
+			IMember member = caller.getMember();
+			if ("useTarget".equals(member.getElementName())) {
+				found = true;
+				// Verify the full declaring type chain
+				IType inner = member.getDeclaringType();
+				assertNotNull(inner,
+						"useTarget declaring type should be Inner");
+				assertEquals("Inner", inner.getElementName());
+				IType middle = inner.getDeclaringType();
+				assertNotNull(middle,
+						"Inner's declaring type should be Middle");
+				assertEquals("Middle", middle.getElementName());
+			}
+		}
+		assertTrue(found,
+				"Should find useTarget as caller. Found: "
+						+ Arrays.stream(callers)
+								.map(c -> c.getMember()
+										.getElementName())
+								.collect(Collectors.joining(", ")));
+	}
+
+	@Test
+	public void testDeeplyNestedReferenceMatchEnclosingElement()
+			throws Exception {
+		// Reference to a Java method from inside a 3-level nested type.
+		// The match element should have the full declaring type chain.
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/deepref");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/deepref/Service.java",
+				"package deepref;\n"
+				+ "public class Service {\n"
+				+ "    public static void serve() {}\n"
+				+ "}\n");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/deepref/Nested.kt",
+				"package deepref\n"
+				+ "\n"
+				+ "class L1 {\n"
+				+ "    class L2 {\n"
+				+ "        class L3 {\n"
+				+ "            fun callServe() {\n"
+				+ "                Service.serve()\n"
+				+ "            }\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		List<SearchMatch> refs = TestHelpers
+				.searchMethodReferences("serve", project);
+		List<SearchMatch> ktRefs = TestHelpers
+				.filterKotlinMatches(refs);
+		assertTrue(ktRefs.size() >= 1,
+				"Should find Kotlin reference to serve");
+
+		IMember enclosing = (IMember) ktRefs.get(0).getElement();
+		assertEquals("callServe", enclosing.getElementName());
+
+		// Verify declaring type chain: callServe → L3 → L2 → L1
+		IType l3 = enclosing.getDeclaringType();
+		assertNotNull(l3, "callServe declaring type should be L3");
+		assertEquals("L3", l3.getElementName());
+
+		IType l2 = l3.getDeclaringType();
+		assertNotNull(l2, "L3's declaring type should be L2");
+		assertEquals("L2", l2.getElementName());
+
+		IType l1 = l2.getDeclaringType();
+		assertNotNull(l1, "L2's declaring type should be L1");
+		assertEquals("L1", l1.getElementName());
+	}
+
+	@Test
+	public void testDeeplyNestedCUModelDeclaringTypeChain()
+			throws Exception {
+		// CU model path: nested types via getChildren() should
+		// have the full declaring type chain at arbitrary depth
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/cudeep");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/cudeep/Root.kt",
+				"package cudeep\n"
+				+ "\n"
+				+ "class Root {\n"
+				+ "    class Branch {\n"
+				+ "        class Leaf {\n"
+				+ "            fun leafFun() {}\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		IFile ktFile = TestHelpers.getFile(
+				"/" + PROJECT_NAME + "/src/cudeep/Root.kt");
+		KotlinCompilationUnit cu = KotlinModelManager.getInstance()
+				.getCompilationUnit(ktFile);
+		assertNotNull(cu, "CU should not be null");
+
+		// Walk: Root → Branch → Leaf
+		IType[] types = cu.getTypes();
+		IType root = null;
+		for (IType t : types) {
+			if ("Root".equals(t.getElementName())) {
+				root = t;
+			}
+		}
+		assertNotNull(root, "Should find Root type");
+
+		// Find Branch in Root's children
+		IType branch = null;
+		for (IJavaElement child : root.getChildren()) {
+			if (child instanceof IType t
+					&& "Branch".equals(t.getElementName())) {
+				branch = t;
+			}
+		}
+		assertNotNull(branch, "Should find Branch in Root");
+		assertNotNull(branch.getDeclaringType(),
+				"Branch should have declaring type");
+		assertEquals("Root", branch.getDeclaringType().getElementName(),
+				"Branch's declaring type should be Root");
+
+		// Find Leaf in Branch's children
+		IType leaf = null;
+		for (IJavaElement child : branch.getChildren()) {
+			if (child instanceof IType t
+					&& "Leaf".equals(t.getElementName())) {
+				leaf = t;
+			}
+		}
+		assertNotNull(leaf, "Should find Leaf in Branch");
+		assertNotNull(leaf.getDeclaringType(),
+				"Leaf should have declaring type");
+		assertEquals("Branch",
+				leaf.getDeclaringType().getElementName(),
+				"Leaf's declaring type should be Branch");
+
+		// Leaf → Branch → Root chain
+		assertNotNull(leaf.getDeclaringType().getDeclaringType(),
+				"Branch (from Leaf) should have declaring type Root");
+		assertEquals("Root",
+				leaf.getDeclaringType().getDeclaringType()
+						.getElementName(),
+				"Full chain: Leaf → Branch → Root");
+	}
+
+	// ---- Bug #12, Bug 2: Kotlin property-style access to Java getters ----
+	//
+	// In Kotlin, `obj.field` accesses a Java getter `getField()`.
+	// Incoming call hierarchy on the Java getter should find Kotlin
+	// callers that use property syntax. Similarly, `obj.field = x`
+	// accesses `setField(x)`.
+
+	@Test
+	public void testIncomingCallsJavaGetterFromKotlinPropertyAccess()
+			throws Exception {
+		// Java class with getter, Kotlin accesses via property syntax
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/propget");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/propget/Metrics.java",
+				"package propget;\n"
+				+ "public class Metrics {\n"
+				+ "    private int counter;\n"
+				+ "    public int getCounter() { return counter; }\n"
+				+ "    public void setCounter(int c) {"
+				+ " this.counter = c; }\n"
+				+ "}\n");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/propget/Consumer.kt",
+				"package propget\n"
+				+ "\n"
+				+ "class Consumer(private val metrics: Metrics) {\n"
+				+ "    fun readMetric(): Int {\n"
+				+ "        return metrics.counter\n"
+				+ "    }\n"
+				+ "    fun writeMetric(value: Int) {\n"
+				+ "        metrics.counter = value\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		// Find the Java getter
+		ICompilationUnit javaCu = TestHelpers.getJavaCompilationUnit(
+				project, "propget", "Metrics.java");
+		IType metricsType = javaCu.getType("Metrics");
+		IMethod getCounter = metricsType.getMethod("getCounter",
+				new String[0]);
+		assertTrue(getCounter.exists(),
+				"Metrics.getCounter() should exist");
+
+		// Incoming calls should find Kotlin property-style access
+		MethodWrapper[] roots = CallHierarchyCore.getDefault()
+				.getCallerRoots(new IMember[] { getCounter });
+		assertEquals(1, roots.length, "Should have one root");
+
+		MethodWrapper[] callers = roots[0].getCalls(
+				new NullProgressMonitor());
+		boolean found = false;
+		for (MethodWrapper caller : callers) {
+			if ("readMetric".equals(
+					caller.getMember().getElementName())) {
+				found = true;
+			}
+		}
+		assertTrue(found,
+				"Incoming calls to getCounter() should find "
+						+ "Kotlin readMetric() which uses "
+						+ "metrics.counter (property syntax). Found: "
+						+ Arrays.stream(callers)
+								.map(c -> c.getMember()
+										.getElementName())
+								.collect(Collectors.joining(", ")));
+	}
+
+	@Test
+	public void testReferenceSearchJavaGetterFromKotlinPropertyAccess()
+			throws Exception {
+		// Lower-level test: search for references to getCounter()
+		// should find Kotlin property-style access metrics.counter
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/propref");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/propref/Data.java",
+				"package propref;\n"
+				+ "public class Data {\n"
+				+ "    private String name;\n"
+				+ "    public String getName() { return name; }\n"
+				+ "    public void setName(String n) {"
+				+ " this.name = n; }\n"
+				+ "}\n");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/propref/Reader.kt",
+				"package propref\n"
+				+ "\n"
+				+ "fun readName(d: Data): String {\n"
+				+ "    return d.name\n"
+				+ "}\n"
+				+ "\n"
+				+ "fun writeName(d: Data, n: String) {\n"
+				+ "    d.name = n\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		// Search for references to getName via SearchEngine
+		List<SearchMatch> refs = TestHelpers
+				.searchMethodReferences("getName", project);
+		List<SearchMatch> ktRefs = TestHelpers
+				.filterKotlinMatches(refs);
+
+		assertTrue(ktRefs.size() >= 1,
+				"Reference search for getName() should find Kotlin "
+						+ "property-style access d.name. "
+						+ "Total refs: " + refs.size()
+						+ ", Kotlin refs: " + ktRefs.size());
+	}
+
+	@Test
+	public void testReferenceSearchJavaGetterWithAcronymPropertyName()
+			throws Exception {
+		// Java getter getPPInsertTimer() for property ppInsertTimer
+		// — consecutive lowercase chars at start form an acronym in getter
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/acronym");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/acronym/Metrics.java",
+				"package acronym;\n"
+				+ "public class Metrics {\n"
+				+ "    private int ppInsertTimer;\n"
+				+ "    private String dbUrl;\n"
+				+ "    public int getPPInsertTimer() {"
+				+ " return ppInsertTimer; }\n"
+				+ "    public String getDBUrl() {"
+				+ " return dbUrl; }\n"
+				+ "}\n");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/acronym/User.kt",
+				"package acronym\n"
+				+ "\n"
+				+ "fun useMetrics(m: Metrics) {\n"
+				+ "    val timer = m.ppInsertTimer\n"
+				+ "    val url = m.dbUrl\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		// Element-based search (like CallerMethodWrapper uses)
+		IType metricsType = project.findType("acronym.Metrics");
+		assertNotNull(metricsType, "Metrics type should exist");
+
+		// Search for getPPInsertTimer references
+		IMethod ppMethod = metricsType.getMethod(
+				"getPPInsertTimer", new String[0]);
+		assertTrue(ppMethod.exists(),
+				"getPPInsertTimer() should exist");
+		SearchPattern ppPattern = SearchPattern.createPattern(
+				ppMethod, IJavaSearchConstants.REFERENCES);
+		List<SearchMatch> ppRefs = TestHelpers.executeSearch(
+				ppPattern, project);
+		List<SearchMatch> ppKtRefs = TestHelpers
+				.filterKotlinMatches(ppRefs);
+		assertTrue(ppKtRefs.size() >= 1,
+				"Element-based search for getPPInsertTimer() "
+						+ "should find Kotlin m.ppInsertTimer. "
+						+ "Total: " + ppRefs.size()
+						+ ", Kotlin: " + ppKtRefs.size());
+
+		// Search for getDBUrl references
+		IMethod dbMethod = metricsType.getMethod(
+				"getDBUrl", new String[0]);
+		assertTrue(dbMethod.exists(), "getDBUrl() should exist");
+		SearchPattern dbPattern = SearchPattern.createPattern(
+				dbMethod, IJavaSearchConstants.REFERENCES);
+		List<SearchMatch> dbRefs = TestHelpers.executeSearch(
+				dbPattern, project);
+		List<SearchMatch> dbKtRefs = TestHelpers
+				.filterKotlinMatches(dbRefs);
+		assertTrue(dbKtRefs.size() >= 1,
+				"Element-based search for getDBUrl() "
+						+ "should find Kotlin m.dbUrl. "
+						+ "Total: " + dbRefs.size()
+						+ ", Kotlin: " + dbKtRefs.size());
+
+		// Also verify string-based search works
+		List<SearchMatch> strRefs = TestHelpers
+				.searchMethodReferences("getPPInsertTimer", project);
+		List<SearchMatch> strKtRefs = TestHelpers
+				.filterKotlinMatches(strRefs);
+		assertTrue(strKtRefs.size() >= 1,
+				"String-based search for getPPInsertTimer() "
+						+ "should find Kotlin m.ppInsertTimer. "
+						+ "Total: " + strRefs.size()
+						+ ", Kotlin: " + strKtRefs.size());
+	}
+
+	@Test
+	public void testReverseSearchKotlinPropertyFindsJavaGetterCalls()
+			throws Exception {
+		// Reverse direction: searching for references to a Kotlin
+		// property should find Java getter/setter calls.
+		// Kotlin: class Person { var name: String = "" }
+		// Java: person.getName(), person.setName("x")
+		// Search for field "name" references → should find Java calls
+		TestHelpers.createFolder("/" + PROJECT_NAME + "/src/reverse");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/reverse/Person.kt",
+				"package reverse\n"
+				+ "\n"
+				+ "class Person {\n"
+				+ "    var name: String = \"\"\n"
+				+ "    var age: Int = 0\n"
+				+ "}\n");
+		TestHelpers.createFile(
+				"/" + PROJECT_NAME + "/src/reverse/JavaCaller.java",
+				"package reverse;\n"
+				+ "public class JavaCaller {\n"
+				+ "    public void readPerson(Person p) {\n"
+				+ "        String n = p.getName();\n"
+				+ "        int a = p.getAge();\n"
+				+ "    }\n"
+				+ "    public void writePerson(Person p) {\n"
+				+ "        p.setName(\"Alice\");\n"
+				+ "        p.setAge(30);\n"
+				+ "    }\n"
+				+ "}\n");
+		TestHelpers.waitUntilIndexesReady();
+
+		// Search for field "name" references — should find Java
+		// getName()/setName() calls
+		List<SearchMatch> nameRefs = TestHelpers
+				.searchFieldReferences("name", project);
+		List<SearchMatch> nameJavaRefs = nameRefs.stream()
+				.filter(m -> m.getResource() != null
+						&& m.getResource().getName()
+								.endsWith(".java"))
+				.toList();
+		assertTrue(nameJavaRefs.size() >= 2,
+				"Field search for 'name' should find Java "
+						+ "getName() and setName() calls. "
+						+ "Total: " + nameRefs.size()
+						+ ", Java: " + nameJavaRefs.size());
+
+		// Search for field "age" references too
+		List<SearchMatch> ageRefs = TestHelpers
+				.searchFieldReferences("age", project);
+		List<SearchMatch> ageJavaRefs = ageRefs.stream()
+				.filter(m -> m.getResource() != null
+						&& m.getResource().getName()
+								.endsWith(".java"))
+				.toList();
+		assertTrue(ageJavaRefs.size() >= 2,
+				"Field search for 'age' should find Java "
+						+ "getAge() and setAge() calls. "
+						+ "Total: " + ageRefs.size()
+						+ ", Java: " + ageJavaRefs.size());
+	}
 }

--- a/co.karellen.jdtls.kotlin/src/co/karellen/jdtls/kotlin/search/KotlinElement.java
+++ b/co.karellen.jdtls.kotlin/src/co/karellen/jdtls/kotlin/search/KotlinElement.java
@@ -489,6 +489,7 @@ public abstract class KotlinElement implements IMember {
 		private final KotlinDeclaration.TypeDeclaration.Kind kind;
 		private final String[] supertypeNames;
 		private IJavaElement[] children;
+		private KotlinTypeElement declaringType;
 
 		public KotlinTypeElement(String name,
 				KotlinCompilationUnit compilationUnit, String packageName,
@@ -520,6 +521,21 @@ public abstract class KotlinElement implements IMember {
 			this.children = children;
 		}
 
+		void setDeclaringType(KotlinTypeElement type) {
+			this.declaringType = type;
+		}
+
+		@Override
+		public IType getDeclaringType() {
+			return declaringType;
+		}
+
+		@Override
+		public IJavaElement getParent() {
+			return declaringType != null ? declaringType
+					: super.getParent();
+		}
+
 		@CoverageExcludeGenerated
 		public String getPackageName() {
 			return packageName;
@@ -544,8 +560,13 @@ public abstract class KotlinElement implements IMember {
 				sb.append(packageName).append('.');
 			}
 			if (enclosingTypeName != null && !enclosingTypeName.isEmpty()) {
-				sb.append(enclosingTypeName)
-						.append(enclosingTypeSeparator);
+				if (enclosingTypeSeparator == '.') {
+					sb.append(enclosingTypeName);
+				} else {
+					sb.append(enclosingTypeName.replace('.',
+							enclosingTypeSeparator));
+				}
+				sb.append(enclosingTypeSeparator);
 			}
 			sb.append(getElementName());
 			return sb.toString();
@@ -632,8 +653,11 @@ public abstract class KotlinElement implements IMember {
 		@Override
 		public String getTypeQualifiedName(char enclosingTypeSeparator) {
 			if (enclosingTypeName != null && !enclosingTypeName.isEmpty()) {
-				return enclosingTypeName + enclosingTypeSeparator
-						+ getElementName();
+				String enc = enclosingTypeSeparator == '.'
+						? enclosingTypeName
+						: enclosingTypeName.replace('.',
+								enclosingTypeSeparator);
+				return enc + enclosingTypeSeparator + getElementName();
 			}
 			return getElementName();
 		}
@@ -1406,6 +1430,7 @@ public abstract class KotlinElement implements IMember {
 				} else if (member instanceof KotlinDeclaration.TypeDeclaration nested) {
 					KotlinTypeElement nestedType = buildTypeElement(
 							nested, cu, packageName);
+					nestedType.setDeclaringType(typeElement);
 					childElements.add(nestedType);
 				}
 			}
@@ -1454,6 +1479,31 @@ public abstract class KotlinElement implements IMember {
 				ctorDecl.getStartOffset(), sourceLength,
 				paramTypes, paramNames, Signature.SIG_VOID,
 				true, ctorDecl.getModifiers());
+	}
+
+	/**
+	 * Creates a synthetic file-facade type for top-level declarations.
+	 * Mirrors the Kotlin compiler convention: {@code FileNameKt} for
+	 * {@code FileName.kt}. JDT infrastructure (e.g.,
+	 * {@code CallSearchResultCollector.isIgnored()}) requires every
+	 * method/field to have a non-null declaring type.
+	 */
+	public static KotlinTypeElement buildFileFacadeType(
+			KotlinCompilationUnit cu, String packageName) {
+		String fileName = cu != null ? cu.getElementName() : "";
+		String baseName;
+		if (fileName.endsWith(".kts")) {
+			baseName = fileName.substring(0,
+					fileName.length() - 4);
+		} else if (fileName.endsWith(".kt")) {
+			baseName = fileName.substring(0,
+					fileName.length() - 3);
+		} else {
+			baseName = fileName;
+		}
+		String facadeName = baseName + "Kt";
+		return new KotlinTypeElement(facadeName, cu, packageName,
+				null, 0, 0, null, new String[0], 0);
 	}
 
 	@CoverageExcludeGenerated

--- a/co.karellen.jdtls.kotlin/src/co/karellen/jdtls/kotlin/search/KotlinFileParser.java
+++ b/co.karellen.jdtls.kotlin/src/co/karellen/jdtls/kotlin/search/KotlinFileParser.java
@@ -188,7 +188,20 @@ public class KotlinFileParser {
 		}
 
 		private String currentEnclosingTypeName() {
-			return enclosingTypeStack.peek();
+			if (enclosingTypeStack.isEmpty()) {
+				return null;
+			}
+			// Stack is front=innermost, back=outermost; join in
+			// reverse (outermost first) to get "Outer.Middle"
+			StringBuilder sb = new StringBuilder();
+			for (var it = enclosingTypeStack.descendingIterator();
+					it.hasNext(); ) {
+				if (sb.length() > 0) {
+					sb.append('.');
+				}
+				sb.append(it.next());
+			}
+			return sb.toString();
 		}
 
 		private List<KotlinDeclaration> currentTarget() {

--- a/co.karellen.jdtls.kotlin/src/co/karellen/jdtls/kotlin/search/KotlinModelManager.java
+++ b/co.karellen.jdtls.kotlin/src/co/karellen/jdtls/kotlin/search/KotlinModelManager.java
@@ -203,21 +203,29 @@ public final class KotlinModelManager {
 		cu.setTypes(types.toArray(
 				new KotlinElement.KotlinTypeElement[0]));
 
-		// Also build top-level functions and properties as children
+		// Build top-level functions and properties as children.
+		// Set synthetic file-facade declaring type — JDT requires
+		// non-null declaring type on every method/field element.
+		KotlinElement.KotlinTypeElement fileFacade =
+				KotlinElement.buildFileFacadeType(cu, packageName);
 		List<IJavaElement> topLevelChildren = new ArrayList<>(types);
 		for (KotlinDeclaration decl : model.getDeclarations()) {
 			if (decl instanceof KotlinDeclaration.MethodDeclaration md) {
-				topLevelChildren.add(
-						KotlinElement.buildMethodElement(md, cu));
+				KotlinElement.KotlinMethodElement me =
+						KotlinElement.buildMethodElement(md, cu);
+				me.setDeclaringType(fileFacade);
+				topLevelChildren.add(me);
 			} else if (decl instanceof KotlinDeclaration.PropertyDeclaration pd) {
 				int len = pd.getEndOffset() - pd.getStartOffset() + 1;
-				topLevelChildren.add(
+				KotlinElement.KotlinFieldElement fe =
 						new KotlinElement.KotlinFieldElement(
 								pd.getName(), cu,
 								pd.getStartOffset(), len,
 								KotlinElement.toTypeSignature(
 										pd.getTypeName()),
-								false, pd.getModifiers()));
+								false, pd.getModifiers());
+				fe.setDeclaringType(fileFacade);
+				topLevelChildren.add(fe);
 			}
 		}
 		cu.setAllChildren(topLevelChildren.toArray(

--- a/co.karellen.jdtls.kotlin/src/co/karellen/jdtls/kotlin/search/KotlinReferenceIndexer.java
+++ b/co.karellen.jdtls.kotlin/src/co/karellen/jdtls/kotlin/search/KotlinReferenceIndexer.java
@@ -44,6 +44,7 @@ public class KotlinReferenceIndexer extends KotlinParserBaseVisitor<Void> {
 	private final SearchDocument document;
 	private final Set<String> indexedTypeRefs = new HashSet<>(); // lowercase keys for case-insensitive dedup
 	private final Map<String, String> aliasToOriginal;
+	private final Set<String> propertyNames = new HashSet<>();
 
 	public KotlinReferenceIndexer(SearchDocument document) {
 		this(document, null);
@@ -208,21 +209,12 @@ public class KotlinReferenceIndexer extends KotlinParserBaseVisitor<Void> {
 										IIndexConstants.METHOD_REF, origKey);
 							}
 						} else {
-							document.addIndexEntry(
-									IIndexConstants.REF,
-									memberName.toCharArray());
-							if (originalMember != null) {
-								document.addIndexEntry(IIndexConstants.REF,
-										originalMember.toCharArray());
-							}
+							indexPropertyAccess(memberName,
+									originalMember);
 						}
 					} else {
-						document.addIndexEntry(IIndexConstants.REF,
-								memberName.toCharArray());
-						if (originalMember != null) {
-							document.addIndexEntry(IIndexConstants.REF,
-									originalMember.toCharArray());
-						}
+						indexPropertyAccess(memberName,
+								originalMember);
 					}
 				}
 			}
@@ -309,6 +301,58 @@ public class KotlinReferenceIndexer extends KotlinParserBaseVisitor<Void> {
 			}
 		}
 		return visitChildren(ctx);
+	}
+
+	/**
+	 * Indexes a property-style access ({@code obj.name} without call
+	 * parens). Emits REF for the property name plus METHOD_REF for
+	 * Java-convention getter/setter names ({@code getName}/{@code setName}).
+	 */
+	private void indexPropertyAccess(String name, String originalName) {
+		document.addIndexEntry(IIndexConstants.REF,
+				name.toCharArray());
+		if (originalName != null) {
+			document.addIndexEntry(IIndexConstants.REF,
+					originalName.toCharArray());
+		}
+		// Also index getter/setter METHOD_REFs for Java interop
+		indexGetterSetterRefs(name);
+		if (originalName != null) {
+			indexGetterSetterRefs(originalName);
+		}
+	}
+
+	private void indexGetterSetterRefs(String propertyName) {
+		if (propertyName.isEmpty()) {
+			return;
+		}
+		// Emit standard getter/setter: capitalize first char
+		String capitalized = Character.toUpperCase(propertyName.charAt(0))
+				+ propertyName.substring(1);
+		emitGetterSetterEntries(capitalized);
+		// Collect for post-indexing JDT lookup of actual getter names
+		propertyNames.add(propertyName);
+	}
+
+	void emitGetterSetterEntries(String capitalizedName) {
+		char[] getKey = MethodPattern.createIndexKey(
+				("get" + capitalizedName).toCharArray(), 0);
+		document.addIndexEntry(IIndexConstants.METHOD_REF, getKey);
+		char[] isKey = MethodPattern.createIndexKey(
+				("is" + capitalizedName).toCharArray(), 0);
+		document.addIndexEntry(IIndexConstants.METHOD_REF, isKey);
+		char[] setKey = MethodPattern.createIndexKey(
+				("set" + capitalizedName).toCharArray(), 1);
+		document.addIndexEntry(IIndexConstants.METHOD_REF, setKey);
+	}
+
+	/**
+	 * Returns the set of property names encountered during indexing.
+	 * Used by KotlinSearchParticipant to look up actual Java getter
+	 * names from the JDT index and emit exact METHOD_REF entries.
+	 */
+	Set<String> getPropertyNames() {
+		return propertyNames;
 	}
 
 	// ---- Callable references (::name, Type::name) ----

--- a/co.karellen.jdtls.kotlin/src/co/karellen/jdtls/kotlin/search/KotlinSearchParticipant.java
+++ b/co.karellen.jdtls.kotlin/src/co/karellen/jdtls/kotlin/search/KotlinSearchParticipant.java
@@ -15,12 +15,14 @@
  */
 package co.karellen.jdtls.kotlin.search;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import co.karellen.jdtls.kotlin.parser.KotlinParser;
 
@@ -33,18 +35,23 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeHierarchy;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
 import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.core.search.SearchDocument;
+import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.jdt.core.search.SearchParticipant;
 import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.core.search.SearchRequestor;
 import org.eclipse.jdt.internal.core.JavaModelManager;
+import org.eclipse.jdt.internal.core.index.EntryResult;
+import org.eclipse.jdt.internal.core.index.Index;
 import org.eclipse.jdt.internal.core.index.IndexLocation;
 import org.eclipse.jdt.internal.core.search.indexing.IIndexConstants;
 import org.eclipse.jdt.internal.core.search.indexing.IndexManager;
@@ -67,7 +74,8 @@ public class KotlinSearchParticipant extends SearchParticipant {
 
 	private record EnclosingContext(
 			KotlinDeclaration decl,
-			KotlinDeclaration.TypeDeclaration type) {
+			KotlinDeclaration.TypeDeclaration typeDecl,
+			KotlinElement.KotlinTypeElement typeElement) {
 	}
 
 	private final KotlinModelManager modelManager =
@@ -361,6 +369,109 @@ public class KotlinSearchParticipant extends SearchParticipant {
 		KotlinReferenceIndexer indexer = new KotlinReferenceIndexer(
 				document, fileModel.getImports());
 		indexer.index(fileModel.getParseTree());
+
+		// Look up actual Java getter/setter names from the JDT index
+		// for property accesses. The ANTLR indexer emits standard forms
+		// (getPpInsertTimer), but the actual Java getter might differ
+		// (getPPInsertTimer). Query the Java method declaration index
+		// to find exact names and emit matching METHOD_REF entries.
+		emitExactGetterSetterRefs(document, indexer);
+	}
+
+	private void emitExactGetterSetterRefs(SearchDocument document,
+			KotlinReferenceIndexer indexer) {
+		Set<String> propertyNames = indexer.getPropertyNames();
+		if (propertyNames.isEmpty()) {
+			return;
+		}
+		// Get project index to query method declarations
+		String docPath = document.getPath();
+		IResource resource = ResourcesPlugin.getWorkspace().getRoot()
+				.findMember(IPath.fromPortableString(docPath));
+		if (resource == null) {
+			return;
+		}
+		IJavaProject javaProject = JavaCore.create(resource.getProject());
+		if (javaProject == null || !javaProject.exists()) {
+			return;
+		}
+		IndexManager indexManager = JavaModelManager.getIndexManager();
+		IPath containerPath = javaProject.getProject().getFullPath();
+		IndexLocation indexLocation =
+				indexManager.computeIndexLocation(containerPath);
+		if (indexLocation == null) {
+			return;
+		}
+		Index index = indexManager.getIndex(indexLocation);
+		if (index == null) {
+			return;
+		}
+		try {
+			for (String propertyName : propertyNames) {
+				String standardCapitalized =
+						Character.toUpperCase(propertyName.charAt(0))
+								+ propertyName.substring(1);
+				// Query METHOD_DECL for getters/setters matching this
+				// property name (case-insensitive prefix match)
+				emitExactEntries(document, index, indexer,
+						"get", standardCapitalized, propertyName);
+				emitExactEntries(document, index, indexer,
+						"is", standardCapitalized, propertyName);
+				emitExactEntries(document, index, indexer,
+						"set", standardCapitalized, propertyName);
+			}
+		} catch (IOException e) {
+			org.eclipse.core.runtime.Platform.getLog(
+					KotlinSearchParticipant.class).warn(
+					"Failed to query Java index for getter names",
+					e);
+		}
+	}
+
+	private void emitExactEntries(SearchDocument document,
+			Index index, KotlinReferenceIndexer indexer,
+			String prefix, String standardCapitalized,
+			String propertyName) throws IOException {
+		String standardName = prefix + standardCapitalized;
+		String standardNameLower = standardName.toLowerCase();
+		// Query for method declarations matching the lowercased
+		// getter name (case-insensitive prefix match finds all casings)
+		EntryResult[] entries = index.query(
+				new char[][] { IIndexConstants.METHOD_DECL },
+				standardNameLower.toCharArray(),
+				SearchPattern.R_PREFIX_MATCH);
+		if (entries == null) {
+			return;
+		}
+		for (EntryResult entry : entries) {
+			char[] word = entry.getWord();
+			// METHOD_DECL index key format: methodName/argCount/...
+			int slash = indexOf(word, '/');
+			if (slash <= 0) {
+				continue;
+			}
+			String methodName = new String(word, 0, slash);
+			if (!methodName.toLowerCase().equals(standardNameLower)) {
+				continue;
+			}
+			// Skip if it's the standard form (already emitted)
+			if (methodName.equals(standardName)) {
+				continue;
+			}
+			// Emit METHOD_REF for this exact getter name
+			String capitalizedVariant =
+					methodName.substring(prefix.length());
+			indexer.emitGetterSetterEntries(capitalizedVariant);
+		}
+	}
+
+	private static int indexOf(char[] array, char ch) {
+		for (int i = 0; i < array.length; i++) {
+			if (array[i] == ch) {
+				return i;
+			}
+		}
+		return -1;
 	}
 
 	private char getSupertypeKind(KotlinDeclaration.TypeDeclaration typeDecl) {
@@ -481,13 +592,24 @@ public class KotlinSearchParticipant extends SearchParticipant {
 
 			if (doDeclarations) {
 				for (KotlinDeclaration decl : fileModel.getDeclarations()) {
-					locateMatchesInDeclaration(decl, pattern, cu,
-							requestor, packageName);
+					locateMatchesInDeclaration(decl, null, pattern,
+							cu, requestor, packageName);
 				}
 			}
 			if (doReferences) {
 				locateReferenceMatches(fileModel, pattern, cu, requestor);
 			}
+		}
+
+		// Reverse direction: when searching for field references to a
+		// Kotlin property, also search for Java getter/setter method
+		// calls via the default Java participant. Only run if the
+		// Kotlin index returned documents (i.e., a Kotlin property
+		// with this name exists).
+		if (documents.length > 0 && pattern instanceof FieldPattern
+				&& isFieldReferenceSearch(pattern)) {
+			searchJavaGetterSetterRefs(pattern, scope, requestor,
+					monitor);
 		}
 	}
 
@@ -522,6 +644,7 @@ public class KotlinSearchParticipant extends SearchParticipant {
 
 
 	private void locateMatchesInDeclaration(KotlinDeclaration decl,
+			KotlinElement.KotlinTypeElement enclosingTypeElement,
 			SearchPattern pattern, KotlinCompilationUnit cu,
 			SearchRequestor requestor, String packageName)
 			throws CoreException {
@@ -536,24 +659,34 @@ public class KotlinSearchParticipant extends SearchParticipant {
 			}
 
 			if (report) {
-				reportTypeMatch(typeDecl, cu, requestor, packageName);
+				reportTypeMatch(typeDecl, enclosingTypeElement, cu,
+						requestor, packageName);
 			}
 
-			// Recurse into all members (nested types, methods, properties)
+			// Build the type element for recursion so children inherit
+			// the full declaring type chain
+			KotlinElement.KotlinTypeElement thisTypeElement =
+					buildTypeElementForDecl(typeDecl, cu,
+							packageName, enclosingTypeElement);
+
+			// Recurse into all members
 			for (KotlinDeclaration member : typeDecl.getMembers()) {
-				locateMatchesInDeclaration(member, pattern, cu, requestor,
-						packageName);
+				locateMatchesInDeclaration(member, thisTypeElement,
+						pattern, cu, requestor, packageName);
 			}
 		} else if (decl instanceof KotlinDeclaration.MethodDeclaration methodDecl) {
 			if (pattern instanceof MethodPattern mp) {
 				if (matchesMethodName(methodDecl, mp)) {
-					reportMethodMatch(methodDecl, cu, requestor, packageName);
+					reportMethodMatch(methodDecl,
+							enclosingTypeElement, cu, requestor,
+							packageName);
 				}
 			}
 		} else if (decl instanceof KotlinDeclaration.PropertyDeclaration propDecl) {
 			if (pattern instanceof FieldPattern) {
 				if (matchesFieldName(propDecl, pattern)) {
-					reportFieldMatch(propDecl, cu, requestor, packageName);
+					reportFieldMatch(propDecl, enclosingTypeElement,
+							cu, requestor, packageName);
 				}
 			}
 		} else if (decl instanceof KotlinDeclaration.TypeAliasDeclaration aliasDecl) {
@@ -598,6 +731,7 @@ public class KotlinSearchParticipant extends SearchParticipant {
 	}
 
 	private void reportTypeMatch(KotlinDeclaration.TypeDeclaration typeDecl,
+			KotlinElement.KotlinTypeElement enclosingTypeElement,
 			KotlinCompilationUnit cu, SearchRequestor requestor,
 			String packageName) throws CoreException {
 		// endOffset is from ANTLR getStopIndex() which is inclusive
@@ -610,6 +744,7 @@ public class KotlinSearchParticipant extends SearchParticipant {
 				typeDecl.getKind(),
 				typeDecl.getSupertypes().toArray(new String[0]),
 				typeDecl.getModifiers());
+		element.setDeclaringType(enclosingTypeElement);
 		SearchMatch match = new SearchMatch(element, SearchMatch.A_ACCURATE,
 				typeDecl.getStartOffset(), sourceLength,
 				this, cu.getResource());
@@ -642,12 +777,16 @@ public class KotlinSearchParticipant extends SearchParticipant {
 
 	private void reportMethodMatch(
 			KotlinDeclaration.MethodDeclaration methodDecl,
+			KotlinElement.KotlinTypeElement enclosingTypeElement,
 			KotlinCompilationUnit cu, SearchRequestor requestor,
 			String packageName) throws CoreException {
 		int sourceLength = methodDecl.getEndOffset()
 				- methodDecl.getStartOffset() + 1;
 		KotlinElement.KotlinMethodElement element = createMethodElement(
 				methodDecl, cu);
+		element.setDeclaringType(enclosingTypeElement != null
+				? enclosingTypeElement
+				: KotlinElement.buildFileFacadeType(cu, packageName));
 		SearchMatch match = new SearchMatch(element, SearchMatch.A_ACCURATE,
 				methodDecl.getStartOffset(), sourceLength,
 				this, cu.getResource());
@@ -656,6 +795,7 @@ public class KotlinSearchParticipant extends SearchParticipant {
 
 	private void reportFieldMatch(
 			KotlinDeclaration.PropertyDeclaration propDecl,
+			KotlinElement.KotlinTypeElement enclosingTypeElement,
 			KotlinCompilationUnit cu, SearchRequestor requestor,
 			String packageName) throws CoreException {
 		int sourceLength = propDecl.getEndOffset()
@@ -665,6 +805,9 @@ public class KotlinSearchParticipant extends SearchParticipant {
 				propDecl.getStartOffset(), sourceLength,
 				KotlinElement.toTypeSignature(propDecl.getTypeName()),
 				false, propDecl.getModifiers());
+		element.setDeclaringType(enclosingTypeElement != null
+				? enclosingTypeElement
+				: KotlinElement.buildFileFacadeType(cu, packageName));
 		SearchMatch match = new SearchMatch(element, SearchMatch.A_ACCURATE,
 				propDecl.getStartOffset(), sourceLength,
 				this, cu.getResource());
@@ -724,6 +867,21 @@ public class KotlinSearchParticipant extends SearchParticipant {
 		List<KotlinReferenceFinder.ReferenceMatch> refMatches = finder
 				.find(fileModel.getParseTree());
 
+		// Kotlin property access (obj.prop) maps to Java getters/setters.
+		// When searching for getX/setX/isX, also find property access to x.
+		if (matchMethods) {
+			String propertyName = derivePropertyName(targetName);
+			if (propertyName != null) {
+				KotlinReferenceFinder propFinder =
+						new KotlinReferenceFinder(propertyName,
+								false, false, true,
+								fileModel.getImports());
+				refMatches = new ArrayList<>(refMatches);
+				refMatches.addAll(propFinder.find(
+						fileModel.getParseTree()));
+			}
+		}
+
 		String packageName = fileModel.getPackageName();
 
 		// Build type resolution infrastructure for receiver verification
@@ -771,10 +929,12 @@ public class KotlinSearchParticipant extends SearchParticipant {
 				EnclosingContext enclosing =
 						findEnclosingDeclarationAndType(
 								fileModel.getDeclarations(),
-								ref.getOffset());
+								ref.getOffset(), cu, packageName);
 				KotlinDeclaration enclosingDecl = enclosing.decl();
 				KotlinDeclaration.TypeDeclaration enclosingType =
-						enclosing.type();
+						enclosing.typeDecl();
+				KotlinElement.KotlinTypeElement enclosingTypeElement =
+						enclosing.typeElement();
 				if (enclosingDecl == null) {
 					continue;
 				}
@@ -861,7 +1021,8 @@ public class KotlinSearchParticipant extends SearchParticipant {
 				}
 
 				KotlinElement element = createElementForDeclaration(
-						enclosingDecl, enclosingType, cu, packageName);
+						enclosingDecl, enclosingTypeElement, cu,
+						packageName);
 				if (element == null) {
 					continue;
 				}
@@ -1197,83 +1358,124 @@ public class KotlinSearchParticipant extends SearchParticipant {
 	}
 
 	private EnclosingContext findEnclosingDeclarationAndType(
-			List<KotlinDeclaration> declarations, int offset) {
-		return findEnclosingDeclarationAndType(declarations, offset, null);
+			List<KotlinDeclaration> declarations, int offset,
+			KotlinCompilationUnit cu, String packageName) {
+		return findEnclosingDeclarationAndType(declarations, offset,
+				null, null, cu, packageName);
 	}
 
 	private EnclosingContext findEnclosingDeclarationAndType(
 			List<KotlinDeclaration> declarations, int offset,
-			KotlinDeclaration.TypeDeclaration currentType) {
+			KotlinDeclaration.TypeDeclaration currentTypeDecl,
+			KotlinElement.KotlinTypeElement currentTypeElement,
+			KotlinCompilationUnit cu, String packageName) {
 		for (KotlinDeclaration decl : declarations) {
 			if (offset >= decl.getStartOffset()
 					&& offset <= decl.getEndOffset()) {
 				if (decl instanceof KotlinDeclaration.TypeDeclaration typeDecl) {
+					KotlinElement.KotlinTypeElement typeElement =
+							buildTypeElementForDecl(typeDecl, cu,
+									packageName,
+									currentTypeElement);
 					EnclosingContext nested =
 							findEnclosingDeclarationAndType(
 									typeDecl.getMembers(), offset,
-									typeDecl);
+									typeDecl, typeElement,
+									cu, packageName);
 					if (nested.decl() != null) {
 						return nested;
 					}
-					return new EnclosingContext(typeDecl, currentType);
+					return new EnclosingContext(typeDecl,
+							currentTypeDecl, currentTypeElement);
 				}
 				if (decl instanceof KotlinDeclaration.MethodDeclaration methodDecl) {
-					// Check nested declarations (local functions)
 					if (!methodDecl.getMembers().isEmpty()) {
 						EnclosingContext nested =
 								findEnclosingDeclarationAndType(
 										methodDecl.getMembers(),
-										offset, currentType);
+										offset, currentTypeDecl,
+										currentTypeElement,
+										cu, packageName);
 						if (nested.decl() != null) {
 							return nested;
 						}
 					}
-					return new EnclosingContext(decl, currentType);
+					return new EnclosingContext(decl,
+							currentTypeDecl, currentTypeElement);
 				}
 				if (decl instanceof KotlinDeclaration.ConstructorDeclaration
 						|| decl instanceof KotlinDeclaration.PropertyDeclaration
 						|| decl instanceof KotlinDeclaration.TypeAliasDeclaration) {
-					return new EnclosingContext(decl, currentType);
+					return new EnclosingContext(decl,
+							currentTypeDecl, currentTypeElement);
 				}
 			}
 		}
-		return new EnclosingContext(null, currentType);
+		return new EnclosingContext(null, currentTypeDecl,
+				currentTypeElement);
 	}
 
 	/**
 	 * Creates a KotlinElement for the given declaration, with proper
 	 * declaring type set for members inside a type.
 	 *
-	 * @param decl          the declaration to create an element for
-	 * @param enclosingType the parent type, or {@code null} for top-level
-	 * @param cu            the compilation unit
-	 * @param packageName   the package name
+	 * @param decl               the declaration to create an element for
+	 * @param enclosingTypeElement the parent type element (with full
+	 *                            declaring type chain), or {@code null}
+	 *                            for top-level
+	 * @param cu                 the compilation unit
+	 * @param packageName        the package name
 	 */
+	private static KotlinElement.KotlinTypeElement buildTypeElementForDecl(
+			KotlinDeclaration.TypeDeclaration typeDecl,
+			KotlinCompilationUnit cu, String packageName,
+			KotlinElement.KotlinTypeElement enclosingTypeElement) {
+		int tLen = typeDecl.getEndOffset()
+				- typeDecl.getStartOffset() + 1;
+		KotlinElement.KotlinTypeElement element =
+				new KotlinElement.KotlinTypeElement(
+						typeDecl.getName(), cu, packageName,
+						typeDecl.getEnclosingTypeName(),
+						typeDecl.getStartOffset(), tLen,
+						typeDecl.getKind(),
+						typeDecl.getSupertypes().toArray(
+								new String[0]),
+						typeDecl.getModifiers());
+		element.setDeclaringType(enclosingTypeElement);
+		return element;
+	}
+
 	private KotlinElement createElementForDeclaration(
 			KotlinDeclaration decl,
-			KotlinDeclaration.TypeDeclaration enclosingType,
+			KotlinElement.KotlinTypeElement enclosingTypeElement,
 			KotlinCompilationUnit cu, String packageName) {
+		KotlinElement.KotlinTypeElement declaringType =
+				enclosingTypeElement != null ? enclosingTypeElement
+						: KotlinElement.buildFileFacadeType(cu,
+								packageName);
 		if (decl instanceof KotlinDeclaration.MethodDeclaration methodDecl) {
 			KotlinElement.KotlinMethodElement me =
 					createMethodElement(methodDecl, cu);
-			me.setDeclaringType(buildDeclaringTypeElement(
-					enclosingType, cu, packageName));
+			me.setDeclaringType(declaringType);
 			return me;
 		} else if (decl instanceof KotlinDeclaration.TypeDeclaration typeDecl) {
 			int sourceLength = typeDecl.getEndOffset()
 					- typeDecl.getStartOffset() + 1;
-			return new KotlinElement.KotlinTypeElement(
-					typeDecl.getName(), cu, packageName,
-					typeDecl.getEnclosingTypeName(),
-					typeDecl.getStartOffset(), sourceLength,
-					typeDecl.getKind(),
-					typeDecl.getSupertypes().toArray(new String[0]),
-					typeDecl.getModifiers());
+			KotlinElement.KotlinTypeElement te =
+					new KotlinElement.KotlinTypeElement(
+							typeDecl.getName(), cu, packageName,
+							typeDecl.getEnclosingTypeName(),
+							typeDecl.getStartOffset(), sourceLength,
+							typeDecl.getKind(),
+							typeDecl.getSupertypes().toArray(
+									new String[0]),
+							typeDecl.getModifiers());
+			te.setDeclaringType(enclosingTypeElement);
+			return te;
 		} else if (decl instanceof KotlinDeclaration.ConstructorDeclaration ctorDecl) {
 			KotlinElement.KotlinMethodElement me =
 					createConstructorElement(ctorDecl, cu);
-			me.setDeclaringType(buildDeclaringTypeElement(
-					enclosingType, cu, packageName));
+			me.setDeclaringType(declaringType);
 			return me;
 		} else if (decl instanceof KotlinDeclaration.PropertyDeclaration propDecl) {
 			int sourceLength = propDecl.getEndOffset()
@@ -1285,36 +1487,21 @@ public class KotlinSearchParticipant extends SearchParticipant {
 							KotlinElement.toTypeSignature(
 									propDecl.getTypeName()),
 							false, propDecl.getModifiers());
-			fe.setDeclaringType(buildDeclaringTypeElement(
-					enclosingType, cu, packageName));
+			fe.setDeclaringType(declaringType);
 			return fe;
 		} else if (decl instanceof KotlinDeclaration.TypeAliasDeclaration aliasDecl) {
 			int sourceLength = aliasDecl.getEndOffset()
 					- aliasDecl.getStartOffset() + 1;
-			return new KotlinElement.KotlinTypeElement(
-					aliasDecl.getName(), cu, packageName,
-					aliasDecl.getEnclosingTypeName(),
-					aliasDecl.getStartOffset(), sourceLength,
-					null, null, aliasDecl.getModifiers());
+			KotlinElement.KotlinTypeElement te =
+					new KotlinElement.KotlinTypeElement(
+							aliasDecl.getName(), cu, packageName,
+							aliasDecl.getEnclosingTypeName(),
+							aliasDecl.getStartOffset(), sourceLength,
+							null, null, aliasDecl.getModifiers());
+			te.setDeclaringType(enclosingTypeElement);
+			return te;
 		}
 		return null;
-	}
-
-	private KotlinElement.KotlinTypeElement buildDeclaringTypeElement(
-			KotlinDeclaration.TypeDeclaration enclosingType,
-			KotlinCompilationUnit cu, String packageName) {
-		if (enclosingType == null) {
-			return null;
-		}
-		int tLen = enclosingType.getEndOffset()
-				- enclosingType.getStartOffset() + 1;
-		return new KotlinElement.KotlinTypeElement(
-				enclosingType.getName(), cu, packageName,
-				enclosingType.getEnclosingTypeName(),
-				enclosingType.getStartOffset(), tLen,
-				enclosingType.getKind(),
-				enclosingType.getSupertypes().toArray(new String[0]),
-				enclosingType.getModifiers());
 	}
 
 	private KotlinElement.KotlinMethodElement createMethodElement(
@@ -1339,6 +1526,98 @@ public class KotlinSearchParticipant extends SearchParticipant {
 		} else if (pattern instanceof FieldPattern fp) {
 			char[] key = fp.getIndexKey();
 			return key != null ? new String(key) : null;
+		}
+		return null;
+	}
+
+	private static boolean isFieldReferenceSearch(SearchPattern pattern) {
+		char[][] categories = pattern.getIndexCategories();
+		if (categories == null) return false;
+		for (char[] cat : categories) {
+			if (Arrays.equals(cat, IIndexConstants.REF)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Reverse direction: when searching for references to a Kotlin
+	 * property, also find Java getter/setter method calls. Runs a
+	 * supplementary search using only the default Java participant.
+	 */
+	private void searchJavaGetterSetterRefs(SearchPattern fieldPattern,
+			IJavaSearchScope scope, SearchRequestor requestor,
+			IProgressMonitor monitor) throws CoreException {
+		String fieldName = extractTargetName(fieldPattern);
+		if (fieldName == null) return;
+
+		List<String> methodNames = deriveGetterSetterNames(fieldName);
+		if (methodNames.isEmpty()) return;
+
+		SearchParticipant[] javaOnly = {
+				SearchEngine.getDefaultSearchParticipant() };
+		SearchEngine engine = new SearchEngine();
+
+		for (String methodName : methodNames) {
+			SearchPattern methodPattern = SearchPattern.createPattern(
+					methodName,
+					IJavaSearchConstants.METHOD,
+					IJavaSearchConstants.REFERENCES,
+					SearchPattern.R_EXACT_MATCH
+							| SearchPattern.R_CASE_SENSITIVE);
+			if (methodPattern == null) continue;
+			engine.search(methodPattern, javaOnly, scope,
+					requestor, monitor);
+		}
+	}
+
+	/**
+	 * Derives Java getter/setter method names from a Kotlin property
+	 * name. {@code name} → {@code [getName, setName]},
+	 * {@code isReady} → {@code [isReady, setReady]}.
+	 */
+	static List<String> deriveGetterSetterNames(String propertyName) {
+		if (propertyName == null || propertyName.isEmpty()) {
+			return Collections.emptyList();
+		}
+		List<String> names = new ArrayList<>(3);
+		// Kotlin boolean properties with "is" prefix: isReady → isReady
+		String lower = propertyName.toLowerCase();
+		if (lower.startsWith("is") && propertyName.length() > 2
+				&& Character.isUpperCase(propertyName.charAt(2))) {
+			names.add(propertyName); // isReady getter
+			names.add("set"
+					+ propertyName.substring(2)); // setReady
+		} else {
+			String cap = Character.toUpperCase(propertyName.charAt(0))
+					+ propertyName.substring(1);
+			names.add("get" + cap);
+			names.add("set" + cap);
+		}
+		return names;
+	}
+
+	/**
+	 * Derives the Kotlin property name from a Java getter/setter name.
+	 * {@code getCounter} → {@code counter}, {@code isReady} → {@code isReady}
+	 * (Kotlin uses {@code isX} directly), {@code setName} → {@code name}.
+	 * Returns {@code null} if the name doesn't follow getter/setter convention.
+	 */
+	static String derivePropertyName(String methodName) {
+		// JDT may pass lowercase selectors for case-insensitive patterns
+		String lower = methodName.toLowerCase();
+		if (lower.length() > 3 && lower.startsWith("get")) {
+			return Character.toLowerCase(methodName.charAt(3))
+					+ methodName.substring(4);
+		}
+		if (lower.length() > 3 && lower.startsWith("set")) {
+			return Character.toLowerCase(methodName.charAt(3))
+					+ methodName.substring(4);
+		}
+		if (lower.length() > 2 && lower.startsWith("is")) {
+			// Kotlin accesses boolean isX as obj.isX (not obj.x)
+			return methodName;
 		}
 		return null;
 	}


### PR DESCRIPTION
## Summary

Fixes #12 — three related issues with cross-language call hierarchy and property/getter search:

- **Null declaring type NPE**: top-level Kotlin functions/properties now get a synthetic file-facade declaring type (`<FileName>Kt`), matching Kotlin's JVM compilation convention. Fixes outgoing call hierarchy NPE (`-32603`) and incoming calls silently returning empty results.

- **Forward direction** (Java getter search finds Kotlin property access): `KotlinReferenceIndexer.indexPropertyAccess()` emits `METHOD_REF` for `getX`/`isX`/`setX`. `derivePropertyName()` handles JDT's lowercase selectors for string-based patterns. For non-standard getter capitalization (e.g., `getPPInsertTimer` → `ppInsertTimer`), queries JDT `METHOD_DECL` index for actual getter names instead of using brittle heuristics.

- **Reverse direction** (Kotlin property search finds Java getter/setter calls): when searching for `FieldPattern` references to a Kotlin property, runs supplementary `SearchEngine.search()` with `MethodPattern` for derived getter/setter names through `SearchEngine.getDefaultSearchParticipant()` only (no recursion into Kotlin participant).

## Verification

- Verified against real mixed Java/Kotlin projects with bidirectional property/getter access
- 275 integration tests passing, 87% instruction / 68% branch coverage

## Test plan

- [x] All 275 integration tests pass
- [x] Forward direction: `testReferenceSearchJavaGetterFromKotlinPropertyAccess`, `testReferenceSearchJavaGetterWithAcronymPropertyName`
- [x] Reverse direction: `testReverseSearchKotlinPropertyFindsJavaGetterCalls`
- [x] Top-level declaring type: `testTopLevelFunctionDeclaringTypeViaDeclarationSearch`, `testTopLevelPropertyDeclaringTypeViaDeclarationSearch`, etc.
- [x] E2E call hierarchy: `testOutgoingCallsWithTopLevelFunctionCallee`, `testIncomingCallsJavaGetterFromKotlinPropertyAccess`
- [x] Verified against real projects